### PR TITLE
#105 Adicionando endpoint de retorno de um repositório mockado

### DIFF
--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -14,8 +14,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/v1/', include('core.urls'))
 ]

--- a/src/core/urls.py
+++ b/src/core/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from core.views import get_mocked_repository
+
+urlpatterns = [
+    path('organizations/1/projects/1/', get_mocked_repository)
+]

--- a/src/core/views.py
+++ b/src/core/views.py
@@ -1,3 +1,14 @@
-from django.shortcuts import render
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
 
-# Create your views here.
+
+@api_view(['GET'])
+def get_mocked_repository(request):
+    return Response({
+        'id': 1,
+        'name': '2022-1-MeasureSoftGram-Front',
+        'description': 'Repositório Frontend do software MeasureSoftGram.',
+        'github_url': 'https://github.com/fga-eps-mds/2022-1-MeasureSoftGram-Front',
+        'created_at': '2022-07-14T020:00:55.603466',
+        'updated_at': '2022-07-15T08:58:55.603466'
+    })


### PR DESCRIPTION
# Cria endpoint de detalhamento do repositório mockado

## Descrição
Adiciona endpoint GET no service para detalhamento de um repositório mockado.

[Visualizar a tela de detalhamento de um repositório](https://github.com/fga-eps-mds/2022-1-MeasureSoftGram-Doc/issues/105)

## Porque este Pull Request é necessário?
Esse pull request é necessário para ser utilizado no desenvolvimento de tela inicial do Frontend.


Closes #105
