### PR TITLE
Add endpoint to calculate subcharacteristics

### DIFF
--- a/src/.vscode/launch.json
+++ b/src/.vscode/launch.json
@@ -14,6 +14,9 @@
                 "0.0.0.0:9090",
             ],
             "django": true,
+            "env": {
+                "CORE_URL": "http://localhost:7000",
+            },
             "justMyCode": false,
         },
         {

--- a/src/service/clients/core_service.py
+++ b/src/service/clients/core_service.py
@@ -8,11 +8,21 @@ class CoreClient:
     def __init__(self):
         self.host = settings.CORE_URL
 
+    @staticmethod
+    def configure_session(session):
+        errors = [500, 502, 503, 504]
+        retries = Retry(total=5, backoff_factor=5, status_forcelist=errors)
+        session.mount("http://", HTTPAdapter(max_retries=retries))
+        session.mount("https://", HTTPAdapter(max_retries=retries))
+
     def calculate_measure(self, params):
         with requests.Session() as session:
-            errors = [500, 502, 503, 504]
-            retries = Retry(total=5, backoff_factor=5, status_forcelist=errors)
-            session.mount("http://", HTTPAdapter(max_retries=retries))
-            session.mount("https://", HTTPAdapter(max_retries=retries))
+            self.configure_session(session)
             url = f'{self.host}/calculate-measures/'
+            return session.post(url, json=params)
+
+    def calculate_subcharacteristic(self, params):
+        with requests.Session() as session:
+            self.configure_session(session)
+            url = f'{self.host}/calculate-subcharacteristics/'
             return session.post(url, json=params)

--- a/src/service/serializers.py
+++ b/src/service/serializers.py
@@ -19,6 +19,6 @@ from service.sub_serializers.subcharacteristics import (
     CalculatedSubCharacteristicHistorySerializer,
     CalculatedSubCharacteristicSerializer,
     LatestCalculatedSubCharacteristicSerializer,
-    SupportedSubCharacteristicSerializer,
     SubcharacteristicsCalculationsRequestSerializer,
+    SupportedSubCharacteristicSerializer,
 )

--- a/src/service/serializers.py
+++ b/src/service/serializers.py
@@ -20,4 +20,5 @@ from service.sub_serializers.subcharacteristics import (
     CalculatedSubCharacteristicSerializer,
     LatestCalculatedSubCharacteristicSerializer,
     SupportedSubCharacteristicSerializer,
+    SubcharacteristicsCalculationsRequestSerializer,
 )

--- a/src/service/sub_models/measures.py
+++ b/src/service/sub_models/measures.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Set
+from typing import Iterable, Set, Union
 
 from django.db import models
 from django.utils import timezone
@@ -75,6 +75,15 @@ class SupportedMeasure(models.Model):
             selected_measures_keys,
             SupportedMeasure,
         )
+
+    def get_latest_measure_value(self) -> Union[None, float]:
+        """
+        Função que recupera o valor mais recente da medida caso exista,
+        caso não exista retorna None
+        """
+        if latest_measure := self.calculated_measures.first():
+            return latest_measure.value
+        return None
 
 
 class CalculatedMeasure(models.Model):

--- a/src/service/sub_models/pre_config.py
+++ b/src/service/sub_models/pre_config.py
@@ -49,6 +49,27 @@ class PreConfig(models.Model):
 
         super().save(*args, **kwargs)
 
+    def get_measure_weight(self, measure_key: str) -> float:
+        """
+        Função que retorna o peso de uma medida.
+
+        Observação: Aqui estou usando um algorítmo O(C * S * M) para
+        simplificar a assinatura da função, pois caso contrário seria
+        necessário passar a haracteristics_key, a subcharacteristics_key e a measure_key. Na pior das hipóteses o C (quantidade de características)
+        será 20, o S (quantidade de subcaracterísticas) será 20 e o M
+        (quantidade de medidas) será 20, o que resulta em um loop de 8000 iterações, o que não é nada.
+        """
+        for characteristic in self.data['characteristics']:
+            for subcharacteristic in characteristic['subcharacteristics']:
+                for measure in subcharacteristic['measures']:
+                    if measure['key'] == measure_key:
+                        # No JSON o peso é um float entre 0 e 100
+                        return measure['weight'] / 100
+
+        raise utils.exceptions.MeasureNotDefinedInPreConfiguration(
+            f'Measure {measure_key} not defined in pre-configuration',
+        )
+
     @staticmethod
     def validate_measures(data: dict):
         """

--- a/src/service/sub_models/pre_config.py
+++ b/src/service/sub_models/pre_config.py
@@ -55,9 +55,11 @@ class PreConfig(models.Model):
 
         Observação: Aqui estou usando um algorítmo O(C * S * M) para
         simplificar a assinatura da função, pois caso contrário seria
-        necessário passar a haracteristics_key, a subcharacteristics_key e a measure_key. Na pior das hipóteses o C (quantidade de características)
+        necessário passar a haracteristics_key, a subcharacteristics_key e a
+        measure_key. Na pior das hipóteses o C (quantidade de características)
         será 20, o S (quantidade de subcaracterísticas) será 20 e o M
-        (quantidade de medidas) será 20, o que resulta em um loop de 8000 iterações, o que não é nada.
+        (quantidade de medidas) será 20, o que resulta em um loop de 8000
+        iterações, o que não é nada.
         """
         for characteristic in self.data['characteristics']:
             for subcharacteristic in characteristic['subcharacteristics']:

--- a/src/service/sub_models/subcharacteristics.py
+++ b/src/service/sub_models/subcharacteristics.py
@@ -35,6 +35,30 @@ class SupportedSubCharacteristic(models.Model):
             self.key = utils.namefy(self.name)
         super().save(*args, **kwargs)
 
+    def get_latest_measure_params(self, pre_config) -> dict:
+        """
+        Função que recupera os valores mais recentes das
+        medidas que essa medida depende para ser calculada
+
+        TODO: - Melhorar a query para o banco de dados.
+              - Desconfio que aqui esteja rolando vários inner joins
+
+        raises:
+            utils.exceptions.MeasureNotDefinedInPreConfiguration:
+                Caso a uma medida não esteja definida no pre_config
+        """
+        measure_params = {}
+
+        for measure in self.measures.all():
+            measure_params['key'] = measure.key
+            measure_params['value'] = measure.get_latest_measure_value()
+
+            measure_params['weight'] = pre_config.get_measure_weight(
+                measure.key,
+            )
+
+        return measure_params
+
     def has_unsupported_measures(
         self,
         measures_keys: Iterable[str],
@@ -84,4 +108,8 @@ class CalculatedSubCharacteristic(models.Model):
     created_at = models.DateTimeField(default=timezone.now)
 
     def __str__(self):
-        return f'Subcharacteristic: {self.subcharacteristic}, Value: {self.value}, Created at: {self.created_at}'
+        return (
+            f'Subcharacteristic: {self.subcharacteristic}, '
+            f'Value: {self.value}, '
+            'Created at: {self.created_at}'
+        )

--- a/src/service/sub_serializers/subcharacteristics.py
+++ b/src/service/sub_serializers/subcharacteristics.py
@@ -1,8 +1,8 @@
 from django.conf import settings
 from rest_framework import serializers
 
-from service import models
 import utils
+from service import models
 
 
 class SupportedSubCharacteristicSerializer(serializers.ModelSerializer):

--- a/src/service/sub_serializers/subcharacteristics.py
+++ b/src/service/sub_serializers/subcharacteristics.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from rest_framework import serializers
 
 from service import models
+import utils
 
 
 class SupportedSubCharacteristicSerializer(serializers.ModelSerializer):
@@ -77,3 +78,48 @@ class CalculatedSubCharacteristicHistorySerializer(serializers.ModelSerializer):
             return CalculatedSubCharacteristicSerializer(qs, many=True).data
         except models.CalculatedSubCharacteristic.DoesNotExist:
             return None
+
+
+class SubcharacteristicsCalculationRequestSerializer(serializers.Serializer):
+    """
+    Serializadora usada para solicitar o cálculo de uma subcaracterística
+    """
+    key = serializers.CharField(max_length=255)
+
+
+class SubcharacteristicsCalculationsRequestSerializer(
+    serializers.Serializer
+):
+    """
+    Serializadora usada para solicitar o cálculo de várias subcaracterísticas
+
+    Aqui estou definindo uma lista de objetos pois é provável que no futuro
+    outros parâmetros além de nome sejam necessários, e deste modo a evolução
+    da API será somente a adição de novas chaves em
+    SubcharacteristicsCalculationRequestSerializer
+    """
+    subcharacteristics = serializers.ListField(
+        child=SubcharacteristicsCalculationRequestSerializer(),
+        required=True,
+    )
+
+    def validate(self, attrs):
+        """
+        Valida se todas as subcaracterísticas solicitadas são suportadas
+        """
+        subcharacteristics_keys = [
+            subchar['key'] for subchar in attrs['subcharacteristics']
+        ]
+
+        unsuported_subchars: str = utils.validate_entity(
+            subcharacteristics_keys,
+            models.SupportedSubCharacteristic.has_unsupported_subcharacteristics
+        )
+
+        if unsuported_subchars:
+            raise serializers.ValidationError((
+                "The following subcharacteristics are "
+                f"not supported: {unsuported_subchars}"
+            ))
+
+        return attrs

--- a/src/service/sub_views/measures.py
+++ b/src/service/sub_views/measures.py
@@ -13,7 +13,9 @@ def calculate_measures(request):
     Calcula uma medida
     """
     # 1. Valida se os dados foram enviados corretamente
-    serializer = serializers.MeasuresCalculationsRequestSerializer(data=request.data)
+    serializer = serializers.MeasuresCalculationsRequestSerializer(
+        data=request.data,
+    )
     serializer.is_valid(raise_exception=True)
     data = serializer.validated_data
 
@@ -49,10 +51,20 @@ def calculate_measures(request):
     }
 
     # 6. Salvando no banco de dados as medidas calculadas
+
+    calculated_measures = []
+
     measure: models.SupportedMeasure
     for measure in qs:
         value = calculated_values[measure.key]
-        measure.calculated_measures.create(value=value)
+        calculated_measures.append(
+            models.CalculatedMeasure(
+                measure=measure,
+                value=value,
+            )
+        )
+
+    models.CalculatedMeasure.objects.bulk_create(calculated_measures)
 
     # 7. Retornando o resultado
     serializer = serializers.LatestMeasuresCalculationsRequestSerializer(

--- a/src/service/sub_views/subcharacteristics.py
+++ b/src/service/sub_views/subcharacteristics.py
@@ -1,6 +1,90 @@
-from rest_framework import mixins, viewsets
+from rest_framework import mixins, viewsets, status
+from rest_framework.decorators import api_view, parser_classes
+from rest_framework.parsers import JSONParser
+from rest_framework.response import Response
 
-from service import models, serializers
+from service import clients, models, serializers
+import utils
+
+
+@api_view(['POST', 'HEAD', 'OPTIONS'])
+@parser_classes([JSONParser])
+def calculate_subcharacteristics(request):
+    # 1. Get validated data
+    serializer = serializers.SubcharacteristicsCalculationsRequestSerializer(
+        data=request.data
+    )
+    serializer.is_valid(raise_exception=True)
+    data = serializer.validated_data
+
+
+    # 2. get queryset
+    subcharacteristics_keys = [
+        subcharacteristic['key']
+        for subcharacteristic in data['subcharacteristics']
+    ]
+    qs = models.SupportedSubCharacteristic.objects.filter(
+        key__in=subcharacteristics_keys
+    )
+
+    pre_config = models.PreConfig.objects.first()
+
+    # 3. get core json response
+    core_params = {'subcharacteristics': []}
+    subchar: models.SupportedSubcharacteristic
+
+    for subchar in qs:
+        try:
+            measure_params = subchar.get_latest_measure_params(pre_config)
+
+        except utils.exceptions.MeasureNotDefinedInPreConfiguration as exc:
+            return Response(
+                {'error': str(exc)},
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            )
+
+        core_params['subcharacteristics'].append({
+            'key': subchar.key,
+            'measures': measure_params,
+        })
+
+    response = clients.CoreClient().calculate_subcharacteristic(core_params)
+
+    if response.ok is False:
+        return Response(response.text, status=response.status_code)
+
+    data = response.json()
+
+    # 4. Save data
+    calculated_values = {
+        subcharacteristic['key']: subcharacteristic['value']
+        for subcharacteristic in data['subcharacteristics']
+    }
+
+    calculated_subcharacteristics = []
+
+    subchar: models.SupportedSubcharacteristic
+    for subchar in qs:
+        value = calculated_values[subchar.key]
+
+        calculated_subcharacteristics.append(
+            models.CalculatedSubCharacteristic(
+                subcharacteristic=subchar,
+                value=value,
+            )
+        )
+
+    models.CalculatedSubCharacteristic.objects.bulk_create(
+        calculated_subcharacteristics
+    )
+
+    # 5. Return data
+    serializer = serializers.LatestCalculatedSubCharacteristicSerializer(
+        qs,
+        many=True,
+    )
+
+    return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
 class SupportedSubCharacteristicModelViewSet(

--- a/src/service/sub_views/subcharacteristics.py
+++ b/src/service/sub_views/subcharacteristics.py
@@ -1,10 +1,10 @@
-from rest_framework import mixins, viewsets, status
+from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import api_view, parser_classes
 from rest_framework.parsers import JSONParser
 from rest_framework.response import Response
 
-from service import clients, models, serializers
 import utils
+from service import clients, models, serializers
 
 
 @api_view(['POST', 'HEAD', 'OPTIONS'])
@@ -16,7 +16,6 @@ def calculate_subcharacteristics(request):
     )
     serializer.is_valid(raise_exception=True)
     data = serializer.validated_data
-
 
     # 2. get queryset
     subcharacteristics_keys = [

--- a/src/service/urls.py
+++ b/src/service/urls.py
@@ -102,5 +102,12 @@ urlpatterns = [
         'organizations/1/repository/1/calculate/measures/',
         views.calculate_measures,
     ),
+
+    path(
+        'organizations/1/repository/1/calculate/subcharacteristics/',
+        views.calculate_subcharacteristics,
+    ),
+
+
     # END REAL Endpoints
 ]

--- a/src/service/views.py
+++ b/src/service/views.py
@@ -7,23 +7,19 @@ from service.sub_views.measures import (
     SupportedMeasureModelViewSet,
     calculate_measures,
 )
-
 from service.sub_views.metrics import (
     CollectedMetricHistoryModelViewSet,
     CollectedMetricModelViewSet,
     LatestCollectedMetricModelViewSet,
     SupportedMetricModelViewSet,
 )
-
 from service.sub_views.mocked_views import (
     get_mocked_measures,
     get_mocked_measures_history,
     get_mocked_repository,
     get_specific_mocked_measure,
 )
-
 from service.sub_views.pre_config import CurrentPreConfigModelViewSet
-
 from service.sub_views.subcharacteristics import (
     CalculatedSubCharacteristicHistoryModelViewSet,
     LatestCalculatedSubCharacteristicModelViewSet,

--- a/src/service/views.py
+++ b/src/service/views.py
@@ -7,21 +7,26 @@ from service.sub_views.measures import (
     SupportedMeasureModelViewSet,
     calculate_measures,
 )
+
 from service.sub_views.metrics import (
     CollectedMetricHistoryModelViewSet,
     CollectedMetricModelViewSet,
     LatestCollectedMetricModelViewSet,
     SupportedMetricModelViewSet,
 )
+
 from service.sub_views.mocked_views import (
     get_mocked_measures,
     get_mocked_measures_history,
     get_mocked_repository,
     get_specific_mocked_measure,
 )
+
 from service.sub_views.pre_config import CurrentPreConfigModelViewSet
+
 from service.sub_views.subcharacteristics import (
     CalculatedSubCharacteristicHistoryModelViewSet,
     LatestCalculatedSubCharacteristicModelViewSet,
     SupportedSubCharacteristicModelViewSet,
+    calculate_subcharacteristics,
 )

--- a/src/utils/exceptions.py
+++ b/src/utils/exceptions.py
@@ -8,3 +8,7 @@ class GithubCollectorParamsException(Exception):
 
 class MissingSupportedMetricException(Exception):
     pass
+
+
+class MeasureNotDefinedInPreConfiguration(Exception):
+    pass


### PR DESCRIPTION
closes [#144](https://github.com/fga-eps-mds/2022-1-MeasureSoftGram-Doc/issues/144)

Adiciona o endpoint `/calculate/subcharacteristics/` que realiza a requisição para o serviço `core` com os pesos e últimos valores das medidas visando calcular e salvar o valor calculado das subcaracterísticas.

#### Para testar basta executar os comandos
```bash
# Popular o banco de dados 
$ python manage.py load_initial_data

$ curl --location --request POST 'http://localhost:8080/api/v1/organizations/1/repository/1/calculate/subcharacteristics/' \
--header 'Content-Type: application/json' \
--data-raw '{
    "subcharacteristics": [
        { "key": "testing_status" },
        { "key": "modifiability" }
    ]
}'
```


