### PR TITLE
Add `/api/v1/entity-relationship-tree/` endpoint

### DIFF
--- a/src/.vscode/launch.json
+++ b/src/.vscode/launch.json
@@ -16,6 +16,7 @@
             "django": true,
             "env": {
                 "CORE_URL": "http://localhost:7000",
+                "DEBUG": "True",
             },
             "justMyCode": false,
         },

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -56,6 +56,7 @@ THIRD_PARTY_APPS = [
     'rest_framework',
     'simple_history',
     'corsheaders',
+    'debug_toolbar',
 ]
 
 APPLICATION_APPS = [
@@ -75,6 +76,7 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'simple_history.middleware.HistoryRequestMiddleware',
     'corsheaders.middleware.CorsMiddleware',
+    "debug_toolbar.middleware.DebugToolbarMiddleware",
 ]
 
 ROOT_URLCONF = 'config.urls'
@@ -197,6 +199,11 @@ DATA_UPLOAD_MAX_NUMBER_FIELDS = int(os.getenv(
     "100000",
 ))
 
+
+if DEBUG:
+    import socket  # only if you haven't already imported this
+    hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
+    INTERNAL_IPS = [ip[: ip.rfind(".")] + ".1" for ip in ips] + ["127.0.0.1", "10.0.2.2"]
 
 GITHUB_METRICS = [
     {

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -13,9 +13,9 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
-from django.conf import settings
 
 urlpatterns = [
     path('admin/', admin.site.urls),

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -15,8 +15,12 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path
+from django.conf import settings
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/v1/', include('service.urls', namespace='service')),
 ]
+
+if settings.DEBUG:
+    urlpatterns.append(path('__debug__/', include('debug_toolbar.urls')))

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -16,3 +16,4 @@ requests==2.28.1
 pytest==7.1.2
 pytest-cov==3.0.0
 pytest-django==4.5.2
+django-debug-toolbar==3.5.0

--- a/src/service/serializers.py
+++ b/src/service/serializers.py
@@ -30,3 +30,6 @@ from service.sub_serializers.subcharacteristics import (
     SubcharacteristicsCalculationsRequestSerializer,
     SupportedSubCharacteristicSerializer,
 )
+from service.sub_serializers.entity_tree import (
+    CharacteristicEntityRelationshipTreeSerializer,
+)

--- a/src/service/serializers.py
+++ b/src/service/serializers.py
@@ -9,6 +9,7 @@ from service.sub_serializers.characteristics import (
 )
 from service.sub_serializers.entity_tree import (
     CharacteristicEntityRelationshipTreeSerializer,
+    pre_config_to_entity_tree,
 )
 from service.sub_serializers.github import GithubCollectorParamsSerializer
 from service.sub_serializers.measures import (

--- a/src/service/serializers.py
+++ b/src/service/serializers.py
@@ -7,6 +7,9 @@ from service.sub_serializers.characteristics import (
     LatestCalculatedCharacteristicSerializer,
     SupportedCharacteristicSerializer,
 )
+from service.sub_serializers.entity_tree import (
+    CharacteristicEntityRelationshipTreeSerializer,
+)
 from service.sub_serializers.github import GithubCollectorParamsSerializer
 from service.sub_serializers.measures import (
     CalculatedMeasureHistorySerializer,
@@ -29,7 +32,4 @@ from service.sub_serializers.subcharacteristics import (
     LatestCalculatedSubCharacteristicSerializer,
     SubcharacteristicsCalculationsRequestSerializer,
     SupportedSubCharacteristicSerializer,
-)
-from service.sub_serializers.entity_tree import (
-    CharacteristicEntityRelationshipTreeSerializer,
 )

--- a/src/service/sub_models/pre_config.py
+++ b/src/service/sub_models/pre_config.py
@@ -83,6 +83,36 @@ class PreConfig(models.Model):
             'not defined in pre-configuration',
         ))
 
+    def get_characteristics_qs(self):
+        characteristics_keys = [
+            charac['key']
+            for charac in self.data["characteristics"]
+        ]
+        return SupportedCharacteristic.objects.filter(
+            key__in=characteristics_keys,
+        )
+
+    def get_subcharacteristics_qs(self):
+        subcharacteristics_keys = [
+            subcharac['key']
+            for charac in self.data["characteristics"]
+            for subcharac in charac['subcharacteristics']
+        ]
+        return SupportedSubCharacteristic.objects.filter(
+            key__in=subcharacteristics_keys,
+        )
+
+    def get_measures_qs(self):
+        measures_keys = [
+            measure['key']
+            for charac in self.data["characteristics"]
+            for subcharac in charac['subcharacteristics']
+            for measure in subcharac['measures']
+        ]
+        return SupportedMeasure.objects.filter(
+            key__in=measures_keys,
+        )
+
     @staticmethod
     def validate_measures(data: dict):
         """

--- a/src/service/sub_serializers/entity_tree.py
+++ b/src/service/sub_serializers/entity_tree.py
@@ -51,3 +51,50 @@ class SubCharacteristicEntityRelationshipTreeSerializer(
             obj.measures.all(),
             many=True,
         ).data
+
+
+def pre_config_to_entity_tree(pre_config: models.PreConfig):
+    """
+    Retorna a árvore de relacionamentos entre as entidades de acordo com
+    as entidades selecionadas na pre configuração.
+    """
+    def qs_to_dict(qs):
+        return {obj.key: obj for obj in qs}
+
+    characteristics_qs = pre_config.get_characteristics_qs()
+    subcharacteristics_qs = pre_config.get_subcharacteristics_qs()
+    measures_qs = pre_config.get_measures_qs()
+
+    characteristics_dict = qs_to_dict(characteristics_qs)
+    subcharacteristics_dict = qs_to_dict(subcharacteristics_qs)
+    measures_dict = qs_to_dict(measures_qs)
+
+    data = []
+
+    for charac in pre_config.data['characteristics']:
+        c_data = service_serializers.SupportedCharacteristicSerializer(
+            characteristics_dict[charac['key']],
+        ).data
+
+        c_data['subcharacteristics'] = []
+
+        for subcharac in charac['subcharacteristics']:
+            s_data = service_serializers.SupportedSubCharacteristicSerializer(
+                subcharacteristics_dict[subcharac['key']],
+            ).data
+
+            s_data['measures'] = []
+
+            for measure in subcharac['measures']:
+
+                m_data = service_serializers.SupportedMeasureSerializer(
+                    measures_dict[measure['key']],
+                ).data
+
+                s_data['measures'].append(m_data)
+
+            c_data['subcharacteristics'].append(s_data)
+
+        data.append(c_data)
+
+    return data

--- a/src/service/sub_serializers/entity_tree.py
+++ b/src/service/sub_serializers/entity_tree.py
@@ -1,0 +1,53 @@
+
+from rest_framework import serializers
+
+from service import models
+from service import serializers as service_serializers
+
+
+class CharacteristicEntityRelationshipTreeSerializer(
+    serializers.ModelSerializer,
+):
+    """
+    Serializer para a árvore de relacionamentos entre as entidades
+    """
+
+    subcharacteristics = serializers.SerializerMethodField()
+
+    class Meta:
+        model = models.SupportedCharacteristic
+        fields = (
+            'id',
+            'name',
+            'key',
+            'description',
+            'subcharacteristics',
+        )
+
+    def get_subcharacteristics(self, obj: models.SupportedCharacteristic):
+        return SubCharacteristicEntityRelationshipTreeSerializer(
+            obj.subcharacteristics.all(),
+            many=True,
+        ).data
+
+
+class SubCharacteristicEntityRelationshipTreeSerializer(
+    serializers.ModelSerializer,
+):
+    measures = serializers.SerializerMethodField()
+
+    class Meta:
+        model = models.SupportedCharacteristic
+        fields = (
+            'id',
+            'name',
+            'key',
+            'description',
+            'measures',
+        )
+
+    def get_measures(self, obj: models.SupportedCharacteristic):
+        return service_serializers.SupportedMeasureSerializer(
+            obj.measures.all(),
+            many=True,
+        ).data

--- a/src/service/sub_views/entity_tree.py
+++ b/src/service/sub_views/entity_tree.py
@@ -26,3 +26,10 @@ def entity_relationship_tree(request):
     )
 
     return Response(serializer.data)
+
+
+@api_view(['GET', 'HEAD', 'OPTIONS'])
+def pre_config_entity_relationship_tree(request):
+    current_pre_config = models.PreConfig.objects.first()
+    entity_tree = serializers.pre_config_to_entity_tree(current_pre_config)
+    return Response(entity_tree)

--- a/src/service/sub_views/entity_tree.py
+++ b/src/service/sub_views/entity_tree.py
@@ -1,0 +1,28 @@
+"""
+Módulo que agrupa as views relacionadas à árvore de entidades. Quando dizemos
+árvore de entidades, estamos falando do relacionamentos entre as entidades.
+Isso é:
+* Características com subcaracterísticas
+* Subcaracterísticas com medidas
+"""
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+from service import models, serializers
+
+
+@api_view(['GET', 'HEAD', 'OPTIONS'])
+def entity_relationship_tree(request):
+    """
+    Retorna a árvore de relacionamentos entre as entidades
+    """
+    qs = models.SupportedCharacteristic.objects.all().prefetch_related(
+        'subcharacteristics', 'subcharacteristics__measures',
+    )
+
+    serializer = serializers.CharacteristicEntityRelationshipTreeSerializer(
+        qs,
+        many=True,
+    )
+
+    return Response(serializer.data)

--- a/src/service/urls.py
+++ b/src/service/urls.py
@@ -105,6 +105,8 @@ repo_router.register(
 
 urlpatterns = [
 
+    path('entity-relationship-tree/', views.entity_relationship_tree),
+
     path('organizations/1/repository/1/', views.get_mocked_repository),
 
     path(

--- a/src/service/urls.py
+++ b/src/service/urls.py
@@ -110,6 +110,11 @@ urlpatterns = [
     path('organizations/1/repository/1/', views.get_mocked_repository),
 
     path(
+        'organizations/1/repository/1/entity-relationship-tree/',
+        views.pre_config_entity_relationship_tree,
+    ),
+
+    path(
         'organizations/1/repository/1/import/sonarqube-metrics/',
         views.import_sonar_metrics_view
     ),

--- a/src/service/views.py
+++ b/src/service/views.py
@@ -7,7 +7,10 @@ from service.sub_views.characteristics import (
 )
 from service.sub_views.collectors.github import import_github_metrics
 from service.sub_views.collectors.sonarqube import import_sonar_metrics_view
-from service.sub_views.entity_tree import entity_relationship_tree
+from service.sub_views.entity_tree import (
+    entity_relationship_tree,
+    pre_config_entity_relationship_tree,
+)
 from service.sub_views.measures import (
     CalculatedMeasureHistoryModelViewSet,
     LatestCalculatedMeasureModelViewSet,

--- a/src/service/views.py
+++ b/src/service/views.py
@@ -7,6 +7,7 @@ from service.sub_views.characteristics import (
 )
 from service.sub_views.collectors.github import import_github_metrics
 from service.sub_views.collectors.sonarqube import import_sonar_metrics_view
+from service.sub_views.entity_tree import entity_relationship_tree
 from service.sub_views.measures import (
     CalculatedMeasureHistoryModelViewSet,
     LatestCalculatedMeasureModelViewSet,
@@ -32,8 +33,4 @@ from service.sub_views.subcharacteristics import (
     LatestCalculatedSubCharacteristicModelViewSet,
     SupportedSubCharacteristicModelViewSet,
     calculate_subcharacteristics,
-)
-
-from service.sub_views.entity_tree import (
-    entity_relationship_tree,
 )

--- a/src/service/views.py
+++ b/src/service/views.py
@@ -33,3 +33,7 @@ from service.sub_views.subcharacteristics import (
     SupportedSubCharacteristicModelViewSet,
     calculate_subcharacteristics,
 )
+
+from service.sub_views.entity_tree import (
+    entity_relationship_tree,
+)


### PR DESCRIPTION
Adiciona o endpoint que irá listar todos os dados necessários para renderizar os filtros do novo componente do dashboard.

![image](https://user-images.githubusercontent.com/31013187/183789598-cc977e3c-6a8a-451d-99a2-adbcb7091fad.png)
