### PR TITLE
Add `/calculate/sqc/` endpoint

### DIFF
--- a/src/service/clients/core_service.py
+++ b/src/service/clients/core_service.py
@@ -2,7 +2,6 @@
 import requests
 from django.conf import settings
 from requests.adapters import HTTPAdapter, Retry
-from rest_framework import status
 
 
 class CoreClient:
@@ -34,4 +33,9 @@ class CoreClient:
     @staticmethod
     def calculate_characteristic(params):
         url = f'{CoreClient.HOST}/calculate-characteristics/'
+        return CoreClient.make_post_request(url, params)
+
+    @staticmethod
+    def calculate_sqc(params):
+        url = f'{CoreClient.HOST}/calculate-sqc/'
         return CoreClient.make_post_request(url, params)

--- a/src/service/sub_views/sqc.py
+++ b/src/service/sub_views/sqc.py
@@ -1,6 +1,10 @@
 from rest_framework import mixins, status, viewsets
+from rest_framework.decorators import api_view, parser_classes
+from rest_framework.parsers import JSONParser
+from rest_framework.response import Response
 
-from service import models, serializers
+import utils
+from service import clients, models, serializers
 
 
 class SQCModelViewSet(
@@ -13,3 +17,43 @@ class SQCModelViewSet(
     """
     queryset = models.SQC.objects.all()
     serializer_class = serializers.SQCSerializer
+
+
+@api_view(['POST', 'HEAD', 'OPTIONS'])
+def calculate_sqc(request):
+    pre_config = models.PreConfig.objects.first()
+    qs = models.SupportedMeasure.objects.all().prefetch_related(
+        'metrics',
+        'metrics__collected_metrics',
+    )
+
+    metrics_data = []
+
+    for measure in qs:
+        metric: models.SupportedMetric
+        for metric in measure.metrics.all():
+            metrics_data.append({
+                'key': metric.key,
+                'value': metric.get_latest_metric_value(),
+                'measure_key': measure.key,
+            })
+
+    core_params = {
+        'pre_config': pre_config.data,
+        'metrics': metrics_data,
+    }
+
+    response = clients.CoreClient.calculate_sqc(core_params)
+
+    if response.ok is False:
+        return Response(response.text, status=response.status_code)
+
+    data = response.json()
+
+    sqc = models.SQC.objects.create(
+        value=data['value'],
+    )
+
+    serializer = serializers.SQCSerializer(sqc)
+
+    return Response(serializer.data, status=status.HTTP_201_CREATED)

--- a/src/service/urls.py
+++ b/src/service/urls.py
@@ -137,5 +137,10 @@ urlpatterns = [
         views.calculate_characteristics,
     ),
 
+    path(
+        'organizations/1/repository/1/calculate/sqc/',
+        views.calculate_sqc,
+    ),
+
     # END REAL Endpoints
 ]

--- a/src/service/views.py
+++ b/src/service/views.py
@@ -26,7 +26,7 @@ from service.sub_views.mocked_views import (
     get_specific_mocked_measure,
 )
 from service.sub_views.pre_config import CurrentPreConfigModelViewSet
-from service.sub_views.sqc import SQCModelViewSet
+from service.sub_views.sqc import SQCModelViewSet, calculate_sqc
 from service.sub_views.subcharacteristics import (
     CalculatedSubCharacteristicHistoryModelViewSet,
     LatestCalculatedSubCharacteristicModelViewSet,


### PR DESCRIPTION
closes [#244](https://github.com/fga-eps-mds/2022-1-MeasureSoftGram-Doc/issues/244)

Esse novo endpoint irá agrupar todos os dados necessários (as métricas e a pré-configuração) para calcular o SQC. Esse cálculo é feito pelo `core`, deste modo atualmente o core está retornando um dado mocado.

Após a obtenção do valor cálculado, o service salva a nova SQC e retorna ao usuário o valor.