### PR TITLE
#234 Add endpoint to create new pré-configs

### DIFF
--- a/src/service/sub_models/pre_config.py
+++ b/src/service/sub_models/pre_config.py
@@ -5,6 +5,7 @@ import utils
 from service.sub_models.characteristics import SupportedCharacteristic
 from service.sub_models.measures import SupportedMeasure
 from service.sub_models.subcharacteristics import SupportedSubCharacteristic
+from utils.exceptions import InvalidPreConfigException
 
 
 class PreConfig(models.Model):
@@ -104,7 +105,7 @@ class PreConfig(models.Model):
         )
 
         if unsuported:
-            raise ValueError(
+            raise InvalidPreConfigException(
                 f"The following measures are not supported: {unsuported}"
             )
 
@@ -113,7 +114,7 @@ class PreConfig(models.Model):
         """
         Verifica se o somatório do peso das medidas é igual a 100
 
-        Raises a `ValueError` caso alguma weight não seja
+        Raises a `InvalidPreConfigException` caso alguma weight não seja
         """
         for characteristic in data['characteristics']:
             for subcharacteristic in characteristic['subcharacteristics']:
@@ -124,7 +125,7 @@ class PreConfig(models.Model):
                 )
 
                 if sum_of_weights != 100:
-                    raise ValueError((
+                    raise InvalidPreConfigException((
                         "The sum of weights of measures of subcharacteristic "
                         f"`{subcharacteristic['key']}` is not 100"
                     ))
@@ -135,7 +136,7 @@ class PreConfig(models.Model):
         Verifica se as subcharacteristics contidas no dicionário `data` são
         suportadas
 
-        Raises a `ValueError` caso alguma subcharacteristic não seja
+        Raises a `InvalidPreConfigException` caso alguma subcharacteristic não seja
         """
         selected_subcharacteristics_set = set()
 
@@ -150,7 +151,7 @@ class PreConfig(models.Model):
         )
 
         if unsuported:
-            raise ValueError(
+            raise InvalidPreConfigException(
                 f"The following subcharacteristics are not supported: {unsuported}"
             )
 
@@ -161,7 +162,7 @@ class PreConfig(models.Model):
         na pré-configuração são realmente relacionadas com as
         subcaracteristicas no modelo
 
-        Raises a `ValueError` caso alguma medida não seja relacionada
+        Raises a `InvalidPreConfigException` caso alguma medida não seja relacionada
         """
 
         for characteristic in data['characteristics']:
@@ -181,7 +182,7 @@ class PreConfig(models.Model):
                     invalid_measures: list = [f"`{key}`" for key in invalid_measures]
                     invalid_measures: str = ', '.join(invalid_measures)
 
-                    raise ValueError((
+                    raise InvalidPreConfigException((
                         "Failed to save pre-config. It is not allowed to "
                         f"associate the measures [{invalid_measures}] with the "
                         f"subcharacteristic {subchar.key}"
@@ -192,7 +193,7 @@ class PreConfig(models.Model):
         """
         Verifica se o somatório do peso das subcharacteristics é igual a 100
 
-        Raises a `ValueError` caso alguma weight não seja
+        Raises a `InvalidPreConfigException` caso alguma weight não seja
         """
         for characteristic in data['characteristics']:
             sum_of_weights: int = sum(
@@ -201,7 +202,7 @@ class PreConfig(models.Model):
             )
 
             if sum_of_weights != 100:
-                raise ValueError((
+                raise InvalidPreConfigException((
                     "The sum of weights of subcharacteristics of "
                     f"characteristic `{characteristic['key']}` is not 100"
                 ))
@@ -212,7 +213,7 @@ class PreConfig(models.Model):
         Verifica se as characteristics contidas no dicionário `data` são
         suportadas
 
-        Raises a `ValueError` caso alguma characteristic não seja
+        Raises a `InvalidPreConfigException` caso alguma characteristic não seja
         """
         selected_characteristics_set = set()
 
@@ -226,7 +227,7 @@ class PreConfig(models.Model):
         )
 
         if unsuported:
-            raise ValueError(
+            raise InvalidPreConfigException(
                 f"The following characteristics are not supported: {unsuported}"
             )
 
@@ -237,7 +238,7 @@ class PreConfig(models.Model):
         characteristics na pré-configuração são realmente relacionadas com as
         characteristics no modelo
 
-        Raises a `ValueError` caso alguma subcharacteristic não seja
+        Raises a `InvalidPreConfigException` caso alguma subcharacteristic não seja
         """
 
         for characteristic in data['characteristics']:
@@ -256,7 +257,7 @@ class PreConfig(models.Model):
                 invalid_subs: list = [f"`{key}`" for key in invalid_subs]
                 invalid_subs: str = ', '.join(invalid_subs)
 
-                raise ValueError((
+                raise InvalidPreConfigException((
                     "Failed to save pre-config. It is not allowed to "
                     f"associate the subcharacteristics [{invalid_subs}] "
                     f"with the characteristic {charact.key}"
@@ -267,7 +268,7 @@ class PreConfig(models.Model):
         """
         Verifica se o somatório do peso das characteristics é igual a 100
 
-        Raises a `ValueError` caso alguma weight não seja
+        Raises a `InvalidPreConfigException` caso alguma weight não seja
         """
         sum_of_weights: int = sum(
             characteristic['weight']
@@ -275,4 +276,17 @@ class PreConfig(models.Model):
         )
 
         if sum_of_weights != 100:
-            raise ValueError("The sum of weights of characteristics is not 100")
+            raise InvalidPreConfigException("The sum of weights of characteristics is not 100")
+
+    @staticmethod
+    def same_as_current_preconfig(data: dict):
+        """
+        Verifica se a pré-configuração é a mesma que a pré-configuração atual
+        """
+        current_preconfig = PreConfig.objects.first()
+
+        if current_preconfig.data == data:
+            raise InvalidPreConfigException((
+                "It is not allowed to create a new "
+                "pre-config equal to the current pre-config."
+            ))

--- a/src/service/sub_serializers/pre_config.py
+++ b/src/service/sub_serializers/pre_config.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from service import models
+from utils.exceptions import InvalidPreConfigException
 
 
 class PreConfigSerializer(serializers.ModelSerializer):
@@ -20,36 +21,20 @@ class PreConfigSerializer(serializers.ModelSerializer):
         if self.instance:
             raise ValueError("It's not allowed to edit a pre-configuration")
 
-        models.PreConfig.validate_measures(
-            attrs['data'],
-        )
+        data = attrs['data']
 
-        models.PreConfig.validate_measures_weights(
-            attrs['data'],
-        )
+        try:
+            models.PreConfig.validate_measures(data)
+            models.PreConfig.validate_measures_weights(data)
+            models.PreConfig.validate_subcharacteristics(data)
+            models.PreConfig.validate_subcharacteristics_measures_relation(data)
+            models.PreConfig.validate_subcharacteristics_weights(data)
+            models.PreConfig.validate_characteristics(data)
+            models.PreConfig.validate_characteristics_subcharacteristics_relation(data)
+            models.PreConfig.validate_characteristics_weights(data)
+            models.PreConfig.same_as_current_preconfig(data)
 
-        models.PreConfig.validate_subcharacteristics(
-            attrs['data'],
-        )
-
-        models.PreConfig.validate_subcharacteristics_measures_relation(
-            attrs['data'],
-        )
-
-        models.PreConfig.validate_subcharacteristics_weights(
-            attrs['data'],
-        )
-
-        models.PreConfig.validate_characteristics(
-            attrs['data'],
-        )
-
-        models.PreConfig.validate_characteristics_subcharacteristics_relation(
-            attrs['data'],
-        )
-
-        models.PreConfig.validate_characteristics_weights(
-            attrs['data'],
-        )
+        except InvalidPreConfigException as exc:
+            raise serializers.ValidationError(exc) from exc
 
         return attrs

--- a/src/service/sub_views/pre_config.py
+++ b/src/service/sub_views/pre_config.py
@@ -13,3 +13,10 @@ class CurrentPreConfigModelViewSet(
         latest_pre_config = models.PreConfig.objects.first()
         serializer = serializers.PreConfigSerializer(latest_pre_config)
         return Response(serializer.data, status.HTTP_200_OK)
+
+
+class CreatePreConfigModelViewSet(
+    mixins.CreateModelMixin,
+    viewsets.GenericViewSet,
+):
+    serializer_class = serializers.PreConfigSerializer

--- a/src/service/urls.py
+++ b/src/service/urls.py
@@ -91,9 +91,15 @@ repo_router.register(
 )
 
 repo_router.register(
-    'current-pre-config',
+    'current/pre-config',
     views.CurrentPreConfigModelViewSet,
     basename='current-pre-config',
+)
+
+repo_router.register(
+    'create/pre-config',
+    views.CreatePreConfigModelViewSet,
+    basename='create-pre-config',
 )
 
 repo_router.register(

--- a/src/service/views.py
+++ b/src/service/views.py
@@ -25,7 +25,10 @@ from service.sub_views.mocked_views import (
     get_mocked_repository,
     get_specific_mocked_measure,
 )
-from service.sub_views.pre_config import CurrentPreConfigModelViewSet
+from service.sub_views.pre_config import (
+    CreatePreConfigModelViewSet,
+    CurrentPreConfigModelViewSet,
+)
 from service.sub_views.sqc import SQCModelViewSet
 from service.sub_views.subcharacteristics import (
     CalculatedSubCharacteristicHistoryModelViewSet,

--- a/src/utils/exceptions.py
+++ b/src/utils/exceptions.py
@@ -10,7 +10,11 @@ class MissingSupportedMetricException(Exception):
     pass
 
 
-class EntityNotDefinedInPreConfiguration(Exception):
+class EntityNotDefinedInPreConfiguration(ValueError):
+    """
+    Exceção criada quando uma entidade é procurada em uma pré-configuração,
+    mas esta entidade não foi selecionada na pré-configuração.
+    """
     pass
 
 
@@ -23,4 +27,8 @@ class MeasureNotDefinedInPreConfiguration(
 class SubCharacteristicNotDefinedInPreConfiguration(
     EntityNotDefinedInPreConfiguration
 ):
+    pass
+
+
+class InvalidPreConfigException(ValueError):
     pass


### PR DESCRIPTION
## Descrição

Implementa **novo** endpoint que permite criar novas pré-configuraç~pes. Uma vez que uma nova pré-configuração é criada, automaticamente ela é considerada a pré-configuração vigente.

* `POST` `/api/v1/organizations/1/repository/1/create/pre-config/`

Visando manter o padrão de nomenclatura previamente definido, o endpoint que retorna a pré-configuração foi alterado:

* De: `/api/v1/organizations/1/repository/1/current-pre-config/`
* Para: `/api/v1/organizations/1/repository/1/current/pre-config/`

A validação das pré-configurações está seguindo as regras definidas pelo cliente, sendo elas:

* O somatório dos pesos das entidades em determinado nível da árvore deve sempre ser igual a 100
* Não devemos permitir a criação de pré-configuração com entidades inválidas
* Não devemos permitir a criação de pré-configurações com entidades válidas em contextos inválidos (como por exemplo, associar uma medida com outra subcaracterística diferente da correta)

closes [#234](https://github.com/fga-eps-mds/2022-1-measuresoftgram-doc/issues/234)

## Como testar?

Para testar o novo endpoint, basta enviar requisições alterando o campo data da pré-configuração.

```bash
curl --location --request POST 'http://localhost:8080/api/v1/organizations/1/repository/1/create/pre-config/' \
--header 'Content-Type: application/json' \
--data-raw '{
    "name": "Nova pré-config",
    "data": {
        "characteristics": [
            {
                "key": "reliability",
                "weight": 51.0,
                "subcharacteristics": [
                    {
                        "key": "testing_status",
                        "weight": 100.0,
                        "measures": [
                            {
                                "key": "passed_tests",
                                "weight": 33
                            },
                            {
                                "key": "test_builds",
                                "weight": 33
                            },
                            {
                                "key": "test_coverage",
                                "weight": 34
                            }
                        ]
                    }
                ]
            },
            {
                "key": "maintainabilityy",
                "weight": 49.0,
                "subcharacteristics": [
                    {
                        "key": "modifiability",
                        "weight": 100.0,
                        "measures": [
                            {
                                "key": "non_complex_file_density",
                                "weight": 33
                            },
                            {
                                "key": "commented_file_density",
                                "weight": 33
                            },
                            {
                                "key": "duplication_absense",
                                "weight": 34
                            }
                        ]
                    }
                ]
            }
        ]
    }
}'
```