### PR TITLE
Update GitHub collector to calculate Team Throughput

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -228,13 +228,13 @@ GITHUB_METRICS = [
         },
     },
     {
-        "key": "number_of_issues_with_bug_label_in_the_last_x_days",
-        "name": "Number of issues with bug label in the last x days",
+        "key": "number_of_resolved_issues_with_US_label_in_the_last_x_days",
+        "name": "Number of resolved issues with US label in the last x days",
         "metric_type": "INT",
-        "api_params": [
+        'api_params': [
             'issues_repository_url',
             'issues_metrics_x_days',
-            'issue_labels',
+            'user_story_label',
         ],
         'methods_params_map': {
             '__init__': {
@@ -242,10 +242,56 @@ GITHUB_METRICS = [
                 'token': 'github_token',
             },
             'metric_method': {
-                'method_name': 'get_number_of_issues_with_such_labels_in_the_last_x_days',
+                'method_name': 'get_number_of_issues_resolved_in_the_last_x_days',
                 'method_params': {
                     'x': 'issues_metrics_x_days',
-                    'labels': 'issue_labels',
+                    'label': 'user_story_label',
+                }
+            }
+        },
+    },
+    {
+        "key": "number_of_issues_with_bug_label_in_the_last_x_days",
+        "name": "Number of issues with bug label in the last x days",
+        "metric_type": "INT",
+        "api_params": [
+            'issues_repository_url',
+            'issues_metrics_x_days',
+            'bug_label',
+        ],
+        'methods_params_map': {
+            '__init__': {
+                'url': 'issues_repository_url',
+                'token': 'github_token',
+            },
+            'metric_method': {
+                'method_name': 'get_total_number_of_issues_in_the_last_x_days',
+                'method_params': {
+                    'x': 'issues_metrics_x_days',
+                    'label': 'bug_label',
+                }
+            }
+        },
+    },
+    {
+        "key": "total_number_of_issues_with_US_label_in_the_last_x_days",
+        "name": "Total number of issues with US label in the last x days",
+        "metric_type": "INT",
+        "api_params": [
+            'issues_repository_url',
+            'issues_metrics_x_days',
+            'user_story_label',
+        ],
+        'methods_params_map': {
+            '__init__': {
+                'url': 'issues_repository_url',
+                'token': 'github_token',
+            },
+            'metric_method': {
+                'method_name': 'get_total_number_of_issues_in_the_last_x_days',
+                'method_params': {
+                    'x': 'issues_metrics_x_days',
+                    'label': 'user_story_label',
                 }
             }
         },

--- a/src/service/collectors/github.py
+++ b/src/service/collectors/github.py
@@ -44,38 +44,10 @@ class GithubMetricCollector:
     def str_to_datetime(date_str):
         return dt.datetime.strptime(date_str, GITHUB_DATETIME_STR_FORMAT)
 
-    # TODO: Mover para core
-    # def get_team_throughput(self, start_date, end_date):
-    #     date_now = dt.datetime.now().strftime(GITHUB_DATETIME_STR_FORMAT)
-    #     issues = len(self.get_issues(start_date, end_date, ""))
-    #     closedIssues = len(self.get_issues("", date_now, "state=closed"))
-    #     return closedIssues/issues
-
-    # def get_resolved_issues_throughput(self, start_date, end_date):
-
-    #     # Todas as issues criadas dentro do período de tempo com o estado closed
-    #     closed_issues = self.get_issues(start_date, end_date, "state=closed")
-
-    #    a = list(
-    #        filter(
-    #            lambda issue: (
-    #                issue["closed_at"] > start_date and
-    #                issue["closed_at"] < end_date
-    #            ),
-    #            closed_issues
-    #        )
-    #    )
-    #
-    #     return len(a) / len(closed_issues)
-
-    # def get_issue_type_timeframe(self, start_date, end_date, type):
-    #     total_issues = len(self.get_issues(start_date, end_date, ""))
-    #     issues = len(self.get_issues(start_date, end_date, f"label={type}"))
-    #     return issues/total_issues
-
     def get_number_of_issues_resolved_in_the_last_x_days(
         self,
         x: int,
+        label: str = '',
     ) -> int:
         """
         metric: number of issues resolved in the last x days
@@ -83,40 +55,30 @@ class GithubMetricCollector:
         if not isinstance(x, int):
             raise ValueError('x must be an integer')
 
-        date_range = DateRange.create_from_today(x)
-
-        return len(self.get_issues(date_range, "state=closed"))
-
-    def get_number_of_issues_with_such_labels_in_the_last_x_days(
-        self,
-        x: int,
-        labels: List[str],
-    ) -> int:
-        if not isinstance(x, int):
-            raise ValueError('x must be an integer')
-
-        # Se a lista for vazia ou ao menos um item não for uma string
-        if not labels or any(not isinstance(label, str) for label in labels):
-            raise ValueError('labels must be a list of strings')
-
-        labels: str = ','.join(labels)
+        if not isinstance(label, str):
+            raise ValueError('label must be a string')
 
         date_range = DateRange.create_from_today(x)
 
-        return len(self.get_issues(date_range, f"labels={labels}"))
+        return len(self.get_issues(date_range, f"state=closed&labels={label}"))
 
     def get_total_number_of_issues_in_the_last_x_days(
         self,
         x: int,
+        label: str = ''
     ) -> int:
         """
         metric: total number of issues in a given timeframe
         """
+        if not isinstance(x, int):
+            raise ValueError('x must be an integer')
+
+        if not isinstance(label, str):
+            raise ValueError('label must be a string')
+
         date_range = DateRange.create_from_today(x)
 
-        issues = self.get_issues(date_range)
-
-        return len(issues)
+        return len(self.get_issues(date_range, f"labels={label}"))
 
     def __get_all_build_pipelines_executed_in_the_last_x_days(
         self,

--- a/src/service/management/commands/load_initial_data.py
+++ b/src/service/management/commands/load_initial_data.py
@@ -79,17 +79,10 @@ class Command(BaseCommand):
                 ],
             },
             {
-                "key": "ci_feedback_time",
-                "metrics": [
-                    {"key": "number_of_build_pipelines_in_the_last_x_days"},
-                    {"key": "runtime_sum_of_build_pipelines_in_the_last_x_days"},
-                ],
-            },
-            {
                 "key": "team_throughput",
                 "metrics": [
-                    {"key": "number_of_resolved_issues_in_the_last_x_days"},
-                    {"key": "total_number_of_issues_in_the_last_x_days"},
+                    {"key": "number_of_resolved_issues_with_US_label_in_the_last_x_days"},
+                    {"key": "total_number_of_issues_with_US_label_in_the_last_x_days"},
                 ],
             },
         ]
@@ -244,6 +237,13 @@ class Command(BaseCommand):
                     {"key": "passed_tests"},
                 ],
             },
+            {
+                "key": "functional_completeness",
+                "name": "Functional Completeness",
+                "measures": [
+                    {"key": "team_throughput"},
+                ],
+            },
         ]
 
         for subcharacteristic in suported_subcharacteristics:
@@ -280,6 +280,13 @@ class Command(BaseCommand):
                 "name": "Maintainability",
                 "subcharacteristics": [
                     {"key": "modifiability"},
+                ]
+            },
+            {
+                "key": "functional_suitability",
+                "name": "Functional Suitability",
+                "subcharacteristics": [
+                    {"key": "functional_completeness"},
                 ]
             },
         ]

--- a/src/service/sub_serializers/github.py
+++ b/src/service/sub_serializers/github.py
@@ -41,9 +41,22 @@ class GithubCollectorParamsSerializer(serializers.Serializer):
     issues_metrics_x_days = serializers.IntegerField(required=False)
     pipeline_metrics_x_days = serializers.IntegerField(required=False)
 
-    issue_labels = serializers.ListField(
-        child=serializers.CharField(max_length=100),
+    bug_label = serializers.CharField(
+        max_length=50,
         required=False,
+        help_text=(
+            'Label used to identify a bug in the given repository.'
+            'For example: BUG'
+        )
+    )
+
+    user_story_label = serializers.CharField(
+        max_length=50,
+        required=False,
+        help_text=(
+            'Label used to identify a user story in the given repository.'
+            'For example: US'
+        )
     )
 
     build_pipeline_names = serializers.ListField(
@@ -73,15 +86,9 @@ class GithubCollectorParamsSerializer(serializers.Serializer):
             'pipelines_repository_url' in data
         )
 
-        has_issue_labels_metrics_params: bool = (
-            'issue_labels' in data and
-            has_issue_metrics_params
-        )
-
         return (
             has_issue_metrics_params or
-            has_pipeline_metrics_params or
-            has_issue_labels_metrics_params
+            has_pipeline_metrics_params
         )
 
     def validate(self, attrs):
@@ -92,16 +99,8 @@ class GithubCollectorParamsSerializer(serializers.Serializer):
         ser definidos para cada uma das métricas suportadas.
         """
         metrics_required_params = {}
-
         for metric in settings.GITHUB_METRICS:
-            metric_default_name = metric['name']
-            prefix = metric_default_name.split(' in the last')[0]
-            correct_metric_name = f'{prefix} in the last X days'
-
-            if 'label' in correct_metric_name:
-                correct_metric_name = correct_metric_name.replace('bug', 'Y')
-
-            metrics_required_params[correct_metric_name] = metric['api_params']
+            metrics_required_params[metric['name']] = metric['api_params']
 
         if not self.has_at_least_one_metrics_params(attrs):
             raise serializers.ValidationError({


### PR DESCRIPTION
## US
Este PR faz parte da US: [Calcular Team Throughput](https://github.com/fga-eps-mds/2022-1-MeasureSoftGram-Doc/issues/257)

## Descrição
As principais alterações realizadas nesse PR foram:
 
- Atualização do GitHub collector para aceitar a label de US (`user_story_label`) e BUG (`bug_label` - ainda não utilizamos em nenhuma medida). O parâmetro `issue_labels` não existe mais e os novos parâmetros de label deixaram de ser uma lista de strings e passaram a ser uma única string, visto que a API do GitHub faz um `AND` com as labels e não um `OU` - não achei necessário permitir ter mais de uma label indicando US/BUG;
- Criação de novas métricas necessárias para calcular a medida Team Throughput;
- Adição da medida Team Throughput e sua subcaracterística e característica ao script `load_initial_data`

## Porque este Pull Request é necessário?
Este PR é necessário para calcular a medida Team Throughput
