### PR TITLE
Fix list of metric values

### DIFF
--- a/src/service/sub_models/measures.py
+++ b/src/service/sub_models/measures.py
@@ -47,20 +47,9 @@ class SupportedMeasure(models.Model):
         """
         metric_params = {}
 
-        # Métricas que o parâmetro é uma lista de valores
-        listed_values: Set[str] = {
-            'coverage', 'complexity', 'functions',
-            'comment_lines_density', 'duplicated_lines_density'
-        }
-
         for supported_metric in self.metrics.all():
             key = supported_metric.key
-
-            if key in listed_values:
-                metric_params[key] = supported_metric.get_latest_metric_values()
-
-            else:
-                metric_params[key] = supported_metric.get_latest_metric_value()
+            metric_params[key] = supported_metric.get_latest_metric_value()
 
         return metric_params
 

--- a/src/service/sub_models/metrics.py
+++ b/src/service/sub_models/metrics.py
@@ -1,5 +1,5 @@
 import datetime as dt
-from typing import Union
+from typing import Union, Set
 
 from django.db import models
 from django.utils import timezone
@@ -40,13 +40,22 @@ class SupportedMetric(models.Model):
     def __str__(self):
         return self.key
 
-    def get_latest_metric_value(self) -> Union[float, str, int, bool]:
+    def get_latest_metric_value(self) -> Union[float, str, int, bool, list]:
         """
         Função que recupera o valor mais recente da métrica
         """
-        if latest_metric := self.collected_metrics.first():
-            return latest_metric.value
-        return None
+        # Métricas que o parâmetro é uma lista de valores
+        listed_values: Set[str] = {
+            'coverage', 'complexity', 'functions',
+            'comment_lines_density', 'duplicated_lines_density'
+        }
+
+        if self.key in listed_values:
+            return self.get_latest_metric_values()
+        else:
+            if latest_metric := self.collected_metrics.first():
+                return latest_metric.value
+            return None
 
     def get_latest_metric_values(self) -> list:
         """

--- a/src/service/sub_models/metrics.py
+++ b/src/service/sub_models/metrics.py
@@ -1,5 +1,4 @@
-import datetime as dt
-from typing import Union, Set
+from typing import Set, Union
 
 from django.db import models
 from django.utils import timezone

--- a/src/service/sub_models/pre_config.py
+++ b/src/service/sub_models/pre_config.py
@@ -66,8 +66,7 @@ class PreConfig(models.Model):
             for subcharacteristic in characteristic['subcharacteristics']:
                 for measure in subcharacteristic['measures']:
                     if measure['key'] == measure_key:
-                        # No JSON o peso é um float entre 0 e 100
-                        return measure['weight'] / 100
+                        return measure['weight']
 
         raise utils.exceptions.MeasureNotDefinedInPreConfiguration(
             f'Measure {measure_key} not defined in pre-configuration',
@@ -77,7 +76,7 @@ class PreConfig(models.Model):
         for characteristic in self.data['characteristics']:
             for subcharacteristic in characteristic['subcharacteristics']:
                 if subcharacteristic['key'] == subcharacteristic_key:
-                    return subcharacteristic['weight'] / 100
+                    return subcharacteristic['weight']
 
         raise utils.exceptions.SubCharacteristicNotDefinedInPreConfiguration((
             f'Subcharacteristic {subcharacteristic_key} '


### PR DESCRIPTION
Este fix é necessário para a US [#254](https://github.com/fga-eps-mds/2022-1-MeasureSoftGram-Doc/issues/254)

## Descrição
- Os valores de métricas enviados na requisição para calcular o SQC não estavam considerando as métricas que são uma lista de valores. Troquei a responsabilidade de recuperar essa lista para a model de métricas.
- Tirei a divisão por 100 dos pesos das medidas e das subcaracterísticas, pois no cálculo do Core o peso é utilizado na escala 0-100, assim como é passado na pre-config pra calcular o SQC
